### PR TITLE
[ fix ] station08のテストを修正 - リダイレクト先をトップページに変更

### DIFF
--- a/spec/station08/create_todo_spec.rb
+++ b/spec/station08/create_todo_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe '作成機能を実装しよう', clear_db: true do
       visit '/todos'
       fill_in 'title', with: 'テストTODO'
       click_button '追加'
-      expect(current_path).to eq '/todos'
+      expect(current_path).to eq '/'
     end
 
     it '作成したTODOが一覧に表示されること' do


### PR DESCRIPTION
### Why

https://techtrain.dev/mypage/railway/43/station/848 にて、テスト2にトップページへ再度リダイレクトするように記載している。
> /todosに POST リクエストを送信したときに、TODO が作成できるようにする。/todosに POST リクエストを受け取るルーティングを追加して、以下の SQL を実行するようにする。実行できたら、トップページに再度リダイレクトするようにしましょう。

しかしながら、現在の実装では、 `/todos` にリダイレクトしているテストになっているため、修正したい。

### What

- リダイレクト先を問題に沿うように `/` へ変更
